### PR TITLE
Fix config-name path in release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,6 +16,6 @@ jobs:
       - name: 🚀 Run Release Drafter
         uses: release-drafter/release-drafter@v6.1.0
         with:
-          config-name: .github/release-drafter.yml
+          config-name: release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request makes a minor update to the release drafter workflow configuration. The change corrects the `config-name` path for the Release Drafter action in `.github/workflows/release-drafter.yml`, ensuring it references `release-drafter.yml` in the repository root instead of the `.github` directory.