### PR TITLE
Remove workflow_dispatch inputs from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,8 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version number (e.g., 1.0.1)'
-        required: true
-        type: string
-      release_notes:
-        description: 'Release notes (optional)'
-        required: false
-        type: string
+  release:
+    types: [published]
 
 jobs:
   release:


### PR DESCRIPTION
This pull request updates the release workflow to trigger automatically when a new GitHub release is published, instead of requiring a manual dispatch with input parameters.

Workflow automation:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L4-R5): Changed the workflow trigger from `workflow_dispatch` (manual with version and notes inputs) to `release` (automatic on release publication).