### PR TITLE
feat(release-drafter): add pre-release option and identifier inputs

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,21 +1,37 @@
+---
 name: Release Drafter
 
+# yamllint disable-line rule:truthy
 on:
   push:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      prerelease:
+        description: "Create a pre-release (beta)"
+        required: false
+        type: boolean
+        default: false
+      prerelease_identifier:
+        description: "Pre-release identifier"
+        required: false
+        type: choice
+        default: "beta"
+        options:
+          - beta
+          - alpha
+          - rc
 
 jobs:
   update_release_draft:
     name: ✏️ Draft release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: 🚀 Run Release Drafter
         uses: release-drafter/release-drafter@v6.1.0
         with:
-          config-name: release-drafter.yml
+          prerelease: ${{ github.event.inputs.prerelease == 'true' }}
+          prerelease-identifier: ${{ github.event.inputs.prerelease_identifier }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/release-drafter.yml` workflow to add support for creating pre-releases directly from the GitHub Actions workflow. The main improvements are the addition of workflow dispatch inputs for pre-release options and passing these options to the Release Drafter action.

**Release workflow improvements:**

* Added `prerelease` and `prerelease_identifier` inputs to the workflow dispatch, allowing users to trigger pre-release (beta, alpha, rc) drafts via the GitHub UI.
* Updated the Release Drafter action step to use these new inputs, enabling automated handling of pre-release flags and identifiers.

<img width="1676" height="537" alt="image" src="https://github.com/user-attachments/assets/6157da09-23dc-4b11-bec9-4c39421619d0" />
