### PR TITLE
Use translations for select entities

### DIFF
--- a/custom_components/bravia_quad/bravia_quad_client.py
+++ b/custom_components/bravia_quad/bravia_quad_client.py
@@ -20,7 +20,6 @@ from .const import (
     CMD_ID_POWER,
     CMD_ID_VOLUME,
     DEFAULT_PORT,
-    DRC_AUTO,
     FEATURE_AAV,
     FEATURE_AUTO_STANDBY,
     FEATURE_BASS_LEVEL,
@@ -55,8 +54,9 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# Default bass level (MID)
-DEFAULT_BASS_LEVEL = 1
+# Default values
+DEFAULT_BASS_LEVEL = 1  # MID
+DEFAULT_DRC = "auto"
 
 
 class BraviaQuadClient:
@@ -82,7 +82,7 @@ class BraviaQuadClient:
         self._night_mode = NIGHT_MODE_OFF
         self._hdmi_cec = HDMI_CEC_OFF
         self._auto_standby = AUTO_STANDBY_OFF
-        self._drc = DRC_AUTO
+        self._drc = DEFAULT_DRC
         self._aav = AAV_OFF
         self._volume_step_interval = 0
         self._command_id_counter = CMD_ID_INITIAL
@@ -557,7 +557,7 @@ class BraviaQuadClient:
             and response.get("type") == "result"
             and response.get("feature") == FEATURE_DRC
         ):
-            self._drc = response.get("value", DRC_AUTO)
+            self._drc = response.get("value", DEFAULT_DRC)
             return self._drc
         return self._drc
 

--- a/custom_components/bravia_quad/const.py
+++ b/custom_components/bravia_quad/const.py
@@ -83,43 +83,15 @@ HDMI_CEC_OFF = "off"
 AUTO_STANDBY_ON = "on"
 AUTO_STANDBY_OFF = "off"
 
-# Dynamic Range Compressor states
-DRC_AUTO = "auto"
-DRC_ON = "on"
-DRC_OFF = "off"
-
 # Advanced Auto Volume states
 AAV_ON = "on"
 AAV_OFF = "off"
 
-# Input options mapping (display name -> value)
-INPUT_OPTIONS = {
-    "TV (eARC)": "tv",
-    "HDMI In": "hdmi1",
-    "Spotify": "spotify",
-    "Bluetooth": "bluetooth",
-    "Airplay": "airplay2",
-}
+# Input options (API values used as translation keys)
+INPUT_OPTIONS: list[str] = ["tv", "hdmi1", "spotify", "bluetooth", "airplay2"]
 
-# Reverse mapping (value -> display name)
-INPUT_VALUES_TO_OPTIONS = {v: k for k, v in INPUT_OPTIONS.items()}
+# Bass level options for non-subwoofer mode (API value -> int)
+BASS_LEVEL_OPTIONS: dict[str, int] = {"min": 0, "mid": 1, "max": 2}
 
-# Bass Level options mapping for non-subwoofer mode (display name -> value)
-BASS_LEVEL_OPTIONS = {
-    "MIN": 0,
-    "MID": 1,
-    "MAX": 2,
-}
-
-# Reverse mapping (value -> display name)
-BASS_LEVEL_VALUES_TO_OPTIONS = {v: k for k, v in BASS_LEVEL_OPTIONS.items()}
-
-# Dynamic Range Compressor options mapping (display name -> value)
-DRC_OPTIONS = {
-    "Auto": "auto",
-    "On": "on",
-    "Off": "off",
-}
-
-# Reverse mapping (value -> display name)
-DRC_VALUES_TO_OPTIONS = {v: k for k, v in DRC_OPTIONS.items()}
+# DRC options (API values used as translation keys)
+DRC_OPTIONS: list[str] = ["auto", "on", "off"]

--- a/custom_components/bravia_quad/translations/en.json
+++ b/custom_components/bravia_quad/translations/en.json
@@ -49,13 +49,30 @@
     },
     "select": {
       "input": {
-        "name": "Source"
+        "name": "Source",
+        "state": {
+          "tv": "TV (eARC)",
+          "hdmi1": "HDMI",
+          "spotify": "Spotify",
+          "bluetooth": "Bluetooth",
+          "airplay2": "AirPlay"
+        }
       },
       "bass_level": {
-        "name": "Bass level"
+        "name": "Bass level",
+        "state": {
+          "min": "Min",
+          "mid": "Mid",
+          "max": "Max"
+        }
       },
       "drc": {
-        "name": "Dynamic Range Compressor"
+        "name": "Dynamic Range Compressor",
+        "state": {
+          "auto": "Auto",
+          "on": "On",
+          "off": "Off"
+        }
       }
     },
     "switch": {

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -56,7 +56,7 @@ class SelectTestCase(NamedTuple):
 
     entity_suffix: str
     feature: str
-    test_values: list[tuple[str, str]]
+    test_values: list[str]
 
 
 # Expected notification features by platform
@@ -99,16 +99,8 @@ NUMBER_TEST_CASES = [
 ]
 
 SELECT_TEST_CASES = [
-    SelectTestCase(
-        "_input",
-        FEATURE_INPUT,
-        [("hdmi1", "HDMI In"), ("bluetooth", "Bluetooth"), ("tv", "TV (eARC)")],
-    ),
-    SelectTestCase(
-        "_drc",
-        FEATURE_DRC,
-        [("on", "On"), ("off", "Off"), ("auto", "Auto")],
-    ),
+    SelectTestCase("_input", FEATURE_INPUT, ["hdmi1", "bluetooth", "tv"]),
+    SelectTestCase("_drc", FEATURE_DRC, ["on", "off", "auto"]),
 ]
 
 
@@ -284,11 +276,9 @@ async def test_select_notification_updates_state(
     callback = _get_registered_callback(mock_bravia_quad_client, test_case.feature)
     assert callback is not None, f"Callback for {test_case.feature} not registered"
 
-    for notification_value, expected_state in test_case.test_values:
-        await callback(notification_value)
+    for value in test_case.test_values:
+        await callback(value)
         await hass.async_block_till_done()
 
         state = hass.states.get(entity_id)
-        assert state.state == expected_state, (
-            f"Expected '{expected_state}' after '{notification_value}' notification"
-        )
+        assert state.state == value, f"Expected '{value}' after '{value}' notification"

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -29,12 +29,13 @@ class InputSelectTestCase(NamedTuple):
     expected_value: str
 
 
+# Options are now the API values directly (used as translation keys)
 INPUT_SELECT_TEST_CASES = [
-    InputSelectTestCase("HDMI In", "hdmi1"),
-    InputSelectTestCase("Spotify", "spotify"),
-    InputSelectTestCase("Bluetooth", "bluetooth"),
-    InputSelectTestCase("Airplay", "airplay2"),
-    InputSelectTestCase("TV (eARC)", "tv"),
+    InputSelectTestCase("hdmi1", "hdmi1"),
+    InputSelectTestCase("spotify", "spotify"),
+    InputSelectTestCase("bluetooth", "bluetooth"),
+    InputSelectTestCase("airplay2", "airplay2"),
+    InputSelectTestCase("tv", "tv"),
 ]
 
 
@@ -76,8 +77,8 @@ async def test_select_entities(
 
     state = hass.states.get(entity_id)
     assert state is not None
-    # Mock returns "tv" which maps to "TV (eARC)"
-    assert state.state == "TV (eARC)"
+    # Mock returns "tv" - state is now the API value
+    assert state.state == "tv"
 
 
 @pytest.mark.usefixtures("init_integration")
@@ -93,14 +94,14 @@ async def test_input_select_option(
     # Verify initial state
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == "TV (eARC)"  # Mock returns "tv" which maps to "TV (eARC)"
+    assert state.state == "tv"  # Mock returns "tv"
 
     mock_bravia_quad_client.async_set_input.return_value = True
 
     await hass.services.async_call(
         SELECT_DOMAIN,
         "select_option",
-        {ATTR_ENTITY_ID: entity_id, "option": "HDMI In"},
+        {ATTR_ENTITY_ID: entity_id, "option": "hdmi1"},
         blocking=True,
     )
 
@@ -110,7 +111,7 @@ async def test_input_select_option(
 @pytest.mark.parametrize(
     ("option", "expected_value"),
     INPUT_SELECT_TEST_CASES,
-    ids=[tc.option.lower().replace(" ", "_") for tc in INPUT_SELECT_TEST_CASES],
+    ids=[tc.option for tc in INPUT_SELECT_TEST_CASES],
 )
 @pytest.mark.usefixtures("init_integration")
 async def test_input_select_options_parametrized(
@@ -151,7 +152,7 @@ async def test_input_select_spotify(
     await hass.services.async_call(
         SELECT_DOMAIN,
         "select_option",
-        {ATTR_ENTITY_ID: entity_id, "option": "Spotify"},
+        {ATTR_ENTITY_ID: entity_id, "option": "spotify"},
         blocking=True,
     )
 
@@ -173,7 +174,7 @@ async def test_input_select_bluetooth(
     await hass.services.async_call(
         SELECT_DOMAIN,
         "select_option",
-        {ATTR_ENTITY_ID: entity_id, "option": "Bluetooth"},
+        {ATTR_ENTITY_ID: entity_id, "option": "bluetooth"},
         blocking=True,
     )
 
@@ -195,7 +196,7 @@ async def test_input_select_airplay(
     await hass.services.async_call(
         SELECT_DOMAIN,
         "select_option",
-        {ATTR_ENTITY_ID: entity_id, "option": "Airplay"},
+        {ATTR_ENTITY_ID: entity_id, "option": "airplay2"},
         blocking=True,
     )
 
@@ -222,7 +223,7 @@ async def test_input_select_fails(
     await hass.services.async_call(
         SELECT_DOMAIN,
         "select_option",
-        {ATTR_ENTITY_ID: entity_id, "option": "HDMI In"},
+        {ATTR_ENTITY_ID: entity_id, "option": "hdmi1"},
         blocking=True,
     )
 
@@ -253,7 +254,7 @@ async def test_input_notification_unknown_value(
     # State should remain unchanged
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == "TV (eARC)"
+    assert state.state == "tv"
 
 
 # =============================================================================
@@ -272,16 +273,16 @@ async def test_drc_select_entity_exists(
 
     state = hass.states.get(entity_id)
     assert state is not None
-    # Default mock value maps to "Auto"
-    assert state.state == "Auto"
+    # Default mock value is "auto"
+    assert state.state == "auto"
 
 
 @pytest.mark.parametrize(
     ("option", "expected_value"),
     [
-        ("Auto", "auto"),
-        ("On", "on"),
-        ("Off", "off"),
+        ("auto", "auto"),
+        ("on", "on"),
+        ("off", "off"),
     ],
     ids=["auto", "on", "off"],
 )
@@ -327,7 +328,7 @@ async def test_drc_select_fails(
     await hass.services.async_call(
         SELECT_DOMAIN,
         "select_option",
-        {ATTR_ENTITY_ID: entity_id, "option": "On"},
+        {ATTR_ENTITY_ID: entity_id, "option": "on"},
         blocking=True,
     )
 
@@ -363,7 +364,7 @@ async def test_drc_notification_updates_state(
 
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == "On"
+    assert state.state == "on"
 
 
 @pytest.mark.usefixtures("init_integration")
@@ -420,8 +421,8 @@ async def test_bass_level_select_created_without_subwoofer(
 
     state = hass.states.get(entity_id)
     assert state is not None
-    # Default mock bass_level=0 maps to "MIN"
-    assert state.state == "MIN"
+    # Default mock bass_level=0 maps to "min"
+    assert state.state == "min"
 
 
 async def test_bass_level_select_not_created_with_subwoofer(
@@ -444,9 +445,9 @@ async def test_bass_level_select_not_created_with_subwoofer(
 @pytest.mark.parametrize(
     ("option", "expected_value"),
     [
-        ("MIN", 0),
-        ("MID", 1),
-        ("MAX", 2),
+        ("min", 0),
+        ("mid", 1),
+        ("max", 2),
     ],
     ids=["min", "mid", "max"],
 )
@@ -504,7 +505,7 @@ async def test_bass_level_select_fails(
     await hass.services.async_call(
         SELECT_DOMAIN,
         "select_option",
-        {ATTR_ENTITY_ID: entity_id, "option": "MAX"},
+        {ATTR_ENTITY_ID: entity_id, "option": "max"},
         blocking=True,
     )
 
@@ -540,12 +541,12 @@ async def test_bass_level_notification_updates_state(
 
     assert bass_callback is not None, "Bass level callback not found"
 
-    # Trigger callback with "2" (MAX)
+    # Trigger callback with "2" (max)
     await bass_callback("2")
 
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == "MAX"
+    assert state.state == "max"
 
 
 async def test_bass_level_notification_invalid_value(


### PR DESCRIPTION
Instead of using the translation as state, use raw value in the state and use translations for the UI. This way, the label can be translated in the right language.

This is breaking change current installation as the state change.

Official doc : https://developers.home-assistant.io/docs/internationalization/core#entity-state-attributes