### PR TITLE
Update release drafter to resolve stable versions from pre-releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -44,7 +44,6 @@ categories:
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
-include-pre-releases: true
 version-resolver:
   major:
     labels:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -26,8 +26,64 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: 🚀 Run Release Drafter (stable)
+      - name: ⤵️ Checkout repository
         if: github.event_name != 'workflow_dispatch' || inputs.release_type == 'stable'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: 🔢 Resolve stable version
+        id: stable_version
+        if: github.event_name != 'workflow_dispatch' || inputs.release_type == 'stable'
+        shell: bash
+        run: |
+          python3 <<'PY' >> "$GITHUB_OUTPUT"
+          import re
+          import subprocess
+
+          prerelease_pattern = re.compile(r"^v(\d+)\.(\d+)\.(\d+)-(alpha|beta|rc)\.\d+$")
+          stable_pattern = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+          tags = subprocess.run(
+              ["git", "tag", "--sort=-version:refname"],
+              capture_output=True,
+              check=True,
+              text=True,
+          ).stdout.splitlines()
+
+          latest_stable: tuple[int, int, int] | None = None
+          latest_prerelease_base: tuple[int, int, int] | None = None
+
+          for tag in tags:
+              if latest_stable is None and (match := stable_pattern.match(tag)):
+                  latest_stable = tuple(int(part) for part in match.groups())
+              if latest_prerelease_base is None and (match := prerelease_pattern.match(tag)):
+                  latest_prerelease_base = tuple(int(part) for part in match.groups()[:3])
+              if latest_stable is not None and latest_prerelease_base is not None:
+                  break
+
+          if latest_prerelease_base and (
+              latest_stable is None or latest_prerelease_base > latest_stable
+          ):
+              version = ".".join(str(part) for part in latest_prerelease_base)
+              print(f"version={version}")
+          PY
+
+      - name: 🚀 Run Release Drafter (stable from prerelease line)
+        if: >-
+          (github.event_name != 'workflow_dispatch' || inputs.release_type == 'stable')
+          && steps.stable_version.outputs.version != ''
+        uses: release-drafter/release-drafter@v6.4.0
+        with:
+          version: ${{ steps.stable_version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🚀 Run Release Drafter (stable default)
+        if: >-
+          (github.event_name != 'workflow_dispatch' || inputs.release_type == 'stable')
+          && steps.stable_version.outputs.version == ''
         uses: release-drafter/release-drafter@v6.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the release workflow to improve how stable versions are determined and released. The main changes include adding a custom step to resolve the correct stable version based on git tags, adjusting the workflow to use this version, and removing pre-release inclusion from the release drafter configuration.

Release workflow improvements:

* Added a new step in `.github/workflows/release-drafter.yml` that checks out the repository and runs a Python script to determine the latest stable version based on git tags, distinguishing between stable and pre-release tags. This ensures that stable releases are based on the latest major/minor/patch line even if the most recent tags are pre-releases.
* Modified the workflow to run Release Drafter with the resolved stable version if available, or fall back to the default behavior if not. This makes the release process more robust and predictable.

Release drafter configuration update:

* Removed the `include-pre-releases: true` line from `.github/release-drafter.yml`, so pre-releases are no longer included when drafting stable releases. This aligns the configuration with the new stable version resolution logic.