### PR TITLE
Add mute/unmute support to media player entity

### DIFF
--- a/custom_components/bravia_quad/bravia_quad_client.py
+++ b/custom_components/bravia_quad/bravia_quad_client.py
@@ -26,6 +26,7 @@ from .const import (
     FEATURE_DRC,
     FEATURE_HDMI_CEC,
     FEATURE_INPUT,
+    FEATURE_MUTE,
     FEATURE_NIGHT_MODE,
     FEATURE_POWER,
     FEATURE_REAR_LEVEL,
@@ -41,6 +42,7 @@ from .const import (
     MIN_BASS_LEVEL_NO_SUB,
     MIN_REAR_LEVEL,
     MIN_VOLUME,
+    MUTE_OFF,
     NIGHT_MODE_OFF,
     POWER_OFF,
     POWER_ON,
@@ -84,6 +86,7 @@ class BraviaQuadClient:
         self._auto_standby = AUTO_STANDBY_OFF
         self._drc = DEFAULT_DRC
         self._aav = AAV_OFF
+        self._mute = MUTE_OFF
         self._volume_step_interval = 0
         self._command_id_counter = CMD_ID_INITIAL
         self._command_lock = asyncio.Lock()
@@ -598,6 +601,43 @@ class BraviaQuadClient:
             return self._aav
         return self._aav
 
+    async def async_set_mute(self, state: str) -> bool:
+        """Set mute state (on/off)."""
+        command = {
+            "id": self._get_next_command_id(),
+            "type": "set",
+            "feature": FEATURE_MUTE,
+            "value": state,
+        }
+        response = await self.async_send_command(command)
+
+        if (
+            response
+            and response.get("type") == "result"
+            and response.get("value") == "ACK"
+        ):
+            self._mute = state
+            return True
+        return False
+
+    async def async_get_mute(self) -> str:
+        """Get current mute state."""
+        command = {
+            "id": self._get_next_command_id(),
+            "type": "get",
+            "feature": FEATURE_MUTE,
+        }
+        response = await self.async_send_command(command)
+
+        if (
+            response
+            and response.get("type") == "result"
+            and response.get("feature") == FEATURE_MUTE
+        ):
+            self._mute = response.get("value", MUTE_OFF)
+            return self._mute
+        return self._mute
+
     async def async_set_rear_level(self, level: int) -> bool:
         """Set rear level (-10 to 10)."""
         if level < MIN_REAR_LEVEL or level > MAX_REAR_LEVEL:
@@ -883,6 +923,11 @@ class BraviaQuadClient:
         return self._aav
 
     @property
+    def mute(self) -> str:
+        """Return current mute state."""
+        return self._mute
+
+    @property
     def volume_step_interval(self) -> int:
         """Return the volume step interval in ms."""
         return self._volume_step_interval
@@ -909,6 +954,7 @@ class BraviaQuadClient:
             self.async_get_auto_standby,
             self.async_get_drc,
             self.async_get_aav,
+            self.async_get_mute,
         ]
 
         for fetch in fetchers:
@@ -921,7 +967,7 @@ class BraviaQuadClient:
             "State fetch complete - Power: %s, Volume: %d, Input: %s, "
             "Rear Level: %d, Bass Level: %d, Voice Enhancer: %s, "
             "Sound Field: %s, Night Mode: %s, HDMI CEC: %s, "
-            "Auto Standby: %s, DRC: %s, AAV: %s",
+            "Auto Standby: %s, DRC: %s, AAV: %s, Mute: %s",
             self._power_state,
             self._volume,
             self._input,
@@ -934,6 +980,7 @@ class BraviaQuadClient:
             self._auto_standby,
             self._drc,
             self._aav,
+            self._mute,
         )
 
     def _get_next_command_id(self) -> int:
@@ -1032,6 +1079,7 @@ class BraviaQuadClient:
             FEATURE_AUTO_STANDBY: self._update_auto_standby_state,
             FEATURE_DRC: self._update_drc_state,
             FEATURE_AAV: self._update_aav_state,
+            FEATURE_MUTE: self._update_mute_state,
         }
 
         handler = feature_handlers.get(feature)
@@ -1092,6 +1140,10 @@ class BraviaQuadClient:
     def _update_aav_state(self, value: Any) -> None:
         """Update Advanced Auto Volume state from value."""
         self._aav = str(value)
+
+    def _update_mute_state(self, value: Any) -> None:
+        """Update mute state from value."""
+        self._mute = str(value)
 
     async def _dispatch_notification_callbacks(
         self, feature: str | None, value: Any

--- a/custom_components/bravia_quad/const.py
+++ b/custom_components/bravia_quad/const.py
@@ -58,6 +58,7 @@ FEATURE_HDMI_CEC = "hdmi.cec"
 FEATURE_AUTO_STANDBY = "system.autostandby"
 FEATURE_DRC = "audio.drangecomp"
 FEATURE_AAV = "audio.aav"
+FEATURE_MUTE = "main.mute"
 
 # Power states
 POWER_ON = "on"
@@ -86,6 +87,10 @@ AUTO_STANDBY_OFF = "off"
 # Advanced Auto Volume states
 AAV_ON = "on"
 AAV_OFF = "off"
+
+# Mute states
+MUTE_ON = "on"
+MUTE_OFF = "off"
 
 # Input options (API values used as translation keys)
 INPUT_OPTIONS: list[str] = ["tv", "hdmi1", "spotify", "bluetooth", "airplay2"]

--- a/custom_components/bravia_quad/media_player.py
+++ b/custom_components/bravia_quad/media_player.py
@@ -15,10 +15,13 @@ from homeassistant.components.media_player import (
 from .const import (
     DOMAIN,
     FEATURE_INPUT,
+    FEATURE_MUTE,
     FEATURE_POWER,
     FEATURE_VOLUME,
     INPUT_OPTIONS,
     MAX_VOLUME,
+    MUTE_OFF,
+    MUTE_ON,
     POWER_OFF,
     POWER_ON,
 )
@@ -57,6 +60,7 @@ class BraviaQuadMediaPlayer(VolumeTransitionMixin, MediaPlayerEntity):
         | MediaPlayerEntityFeature.TURN_OFF
         | MediaPlayerEntityFeature.VOLUME_SET
         | MediaPlayerEntityFeature.VOLUME_STEP
+        | MediaPlayerEntityFeature.VOLUME_MUTE
         | MediaPlayerEntityFeature.SELECT_SOURCE
     )
 
@@ -79,6 +83,9 @@ class BraviaQuadMediaPlayer(VolumeTransitionMixin, MediaPlayerEntity):
 
         # Volume (0-100 -> 0.0-1.0)
         self._attr_volume_level = self._client.volume / MAX_VOLUME
+
+        # Mute
+        self._attr_is_volume_muted = self._client.mute == MUTE_ON
 
         # Source (use raw API value)
         self._attr_source = (
@@ -105,6 +112,11 @@ class BraviaQuadMediaPlayer(VolumeTransitionMixin, MediaPlayerEntity):
                 self.async_write_ha_state()
         except (ValueError, TypeError):
             _LOGGER.warning("Invalid volume notification value: %s", value)
+
+    async def _on_mute_notification(self, value: str) -> None:
+        """Handle mute state notification."""
+        self._attr_is_volume_muted = value == MUTE_ON
+        self.async_write_ha_state()
 
     async def _on_input_notification(self, value: str) -> None:
         """Handle input notification."""
@@ -184,6 +196,16 @@ class BraviaQuadMediaPlayer(VolumeTransitionMixin, MediaPlayerEntity):
         else:
             _LOGGER.error("Failed to set source to %s", source)
 
+    async def async_mute_volume(self, mute: bool) -> None:  # noqa: FBT001
+        """Mute or unmute the soundbar."""
+        state = MUTE_ON if mute else MUTE_OFF
+        success = await self._client.async_set_mute(state)
+        if success:
+            self._attr_is_volume_muted = mute
+            self.async_write_ha_state()
+        else:
+            _LOGGER.error("Failed to set mute to %s", state)
+
     async def async_added_to_hass(self) -> None:
         """Register notification callbacks when entity is added."""
         await super().async_added_to_hass()
@@ -196,6 +218,9 @@ class BraviaQuadMediaPlayer(VolumeTransitionMixin, MediaPlayerEntity):
         self._client.register_notification_callback(
             FEATURE_INPUT, self._on_input_notification
         )
+        self._client.register_notification_callback(
+            FEATURE_MUTE, self._on_mute_notification
+        )
 
     async def async_will_remove_from_hass(self) -> None:
         """Unregister callbacks and cancel any ongoing transition."""
@@ -207,6 +232,9 @@ class BraviaQuadMediaPlayer(VolumeTransitionMixin, MediaPlayerEntity):
         )
         self._client.unregister_notification_callback(
             FEATURE_INPUT, self._on_input_notification
+        )
+        self._client.unregister_notification_callback(
+            FEATURE_MUTE, self._on_mute_notification
         )
         self._cancel_volume_transition()
         await super().async_will_remove_from_hass()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,6 +182,11 @@ def mock_bravia_quad_client() -> Generator[MagicMock]:
         client.async_set_aav = AsyncMock(return_value=True)
         client.aav = "off"
 
+        # Mute
+        client.async_get_mute = AsyncMock(return_value="off")
+        client.async_set_mute = AsyncMock(return_value=True)
+        client.mute = "off"
+
         # Send command (for bluetooth pairing)
         client.async_send_command = AsyncMock(return_value={"value": "ACK"})
 

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -8,10 +8,12 @@ import pytest
 from homeassistant.components.media_player import (
     ATTR_INPUT_SOURCE,
     ATTR_MEDIA_VOLUME_LEVEL,
+    ATTR_MEDIA_VOLUME_MUTED,
     SERVICE_SELECT_SOURCE,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     SERVICE_VOLUME_DOWN,
+    SERVICE_VOLUME_MUTE,
     SERVICE_VOLUME_SET,
     SERVICE_VOLUME_UP,
     MediaPlayerEntityFeature,
@@ -68,12 +70,14 @@ async def test_media_player_entity_created(
         | MediaPlayerEntityFeature.TURN_OFF
         | MediaPlayerEntityFeature.VOLUME_SET
         | MediaPlayerEntityFeature.VOLUME_STEP
+        | MediaPlayerEntityFeature.VOLUME_MUTE
         | MediaPlayerEntityFeature.SELECT_SOURCE
     )
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == expected_features
 
     # Verify initial attributes
     assert state.attributes[ATTR_MEDIA_VOLUME_LEVEL] == 0.5  # 50/100
+    assert state.attributes[ATTR_MEDIA_VOLUME_MUTED] is False
     assert state.attributes[ATTR_INPUT_SOURCE] == "tv"
 
 
@@ -268,6 +272,7 @@ async def test_media_player_notification_callbacks_registered(
     assert "main.power" in registered_features
     assert "main.volumestep" in registered_features
     assert "main.input" in registered_features
+    assert "main.mute" in registered_features
 
 
 @pytest.mark.usefixtures("init_integration")
@@ -293,3 +298,90 @@ async def test_media_player_off_state(
 
     state = hass.states.get(entity_id)
     assert state.state == MediaPlayerState.OFF
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_media_player_mute(
+    hass: HomeAssistant,
+    mock_bravia_quad_client: MagicMock,
+) -> None:
+    """Test muting the media player."""
+    entity_id = _get_media_player_entity_id(hass)
+
+    mock_bravia_quad_client.async_set_mute.return_value = True
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_VOLUME_MUTE,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_MEDIA_VOLUME_MUTED: True,
+        },
+        blocking=True,
+    )
+
+    mock_bravia_quad_client.async_set_mute.assert_called_once_with("on")
+
+    # Verify state updated
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_MEDIA_VOLUME_MUTED] is True
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_media_player_unmute(
+    hass: HomeAssistant,
+    mock_bravia_quad_client: MagicMock,
+) -> None:
+    """Test unmuting the media player."""
+    entity_id = _get_media_player_entity_id(hass)
+
+    mock_bravia_quad_client.async_set_mute.return_value = True
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_VOLUME_MUTE,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_MEDIA_VOLUME_MUTED: False,
+        },
+        blocking=True,
+    )
+
+    mock_bravia_quad_client.async_set_mute.assert_called_once_with("off")
+
+    # Verify state updated
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_MEDIA_VOLUME_MUTED] is False
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_media_player_mute_notification(
+    hass: HomeAssistant,
+    mock_bravia_quad_client: MagicMock,
+) -> None:
+    """Test mute notification updates state."""
+    entity_id = _get_media_player_entity_id(hass)
+
+    # Find the mute notification callback
+    callback_calls = (
+        mock_bravia_quad_client.register_notification_callback.call_args_list
+    )
+    mute_callback = None
+    for call in callback_calls:
+        if call[0][0] == "main.mute":
+            mute_callback = call[0][1]
+            break
+
+    assert mute_callback is not None
+
+    # Simulate mute notification from device
+    await mute_callback("on")
+
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_MEDIA_VOLUME_MUTED] is True
+
+    # Simulate unmute notification
+    await mute_callback("off")
+
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_MEDIA_VOLUME_MUTED] is False


### PR DESCRIPTION
 - Add mute/unmute support to the media player entity via the device's `main.mute` feature on the JSON-over-TCP API (port 33336)
 - Wire up real-time notification handling so mute state stays in sync when changed via IR remote or other sources
 - Add `VOLUME_MUTE` to supported features, which enables the native HA mute toggle in the media player card

New tests added.  Has been tested against a real HT-A9M2.