### PR TITLE
Implement automatic reconnection and entity availability tracking

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -29,7 +29,10 @@ max-complexity = 25
 "tests/*" = [
     "ARG001",  # Allow unused function arguments (fixtures need to be referenced)
     "D",       # Don't require docstrings in tests
+    "FBT001",  # Allow boolean positional args in test helper signatures
+    "FBT003",  # Allow boolean positional values in test assertions and mock calls
     "PLR2004", # Allow magic values in tests (common for test assertions)
     "S101",    # Allow assert statements in tests (pytest uses them)
+    "SLF001",  # Allow private member access in tests (needed to set up internal state)
     "TC002",   # Allow runtime imports in tests (needed for entity_registry, MockConfigEntry, etc.)
 ]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -25,7 +25,15 @@ keep-runtime-typing = true
 max-complexity = 25
 
 [lint.per-file-ignores]
-"scripts/*" = ["T20"]  # Allow print statements in scripts
+"scripts/*" = [
+    "D",       # Don't require docstrings in scripts
+    "FBT001",  # Allow boolean positional args in scripts
+    "PLR0915", # Allow many statements in scripts (long procedural flows)
+    "PLW2901", # Allow loop variable reassignment in scripts
+    "S101",    # Allow assert statements in scripts
+    "SLF001",  # Allow private member access in scripts
+    "T20",     # Allow print statements in scripts
+]
 "tests/*" = [
     "ARG001",  # Allow unused function arguments (fixtures need to be referenced)
     "D",       # Don't require docstrings in tests

--- a/custom_components/bravia_quad/bravia_quad_client.py
+++ b/custom_components/bravia_quad/bravia_quad_client.py
@@ -106,7 +106,7 @@ class BraviaQuadClient:
         self._pending_responses: dict[int, asyncio.Future] = {}
         self._listener_task: asyncio.Task | None = None
         self._background_tasks: set[asyncio.Task] = set()
-        self._availability_callbacks: list[Callable[[bool], None]] = []
+        self._availability_callbacks: set[Callable[[bool], None]] = set()
 
     async def async_connect(self) -> None:
         """Connect to the Bravia Quad device."""
@@ -820,22 +820,16 @@ class BraviaQuadClient:
 
     def register_availability_callback(self, callback: Callable[[bool], None]) -> None:
         """Register a callback for connection state changes."""
-        if not isinstance(self._availability_callbacks, set):
-            self._availability_callbacks = set(self._availability_callbacks)
         self._availability_callbacks.add(callback)
 
     def unregister_availability_callback(
         self, callback: Callable[[bool], None]
     ) -> None:
         """Unregister a connection state change callback."""
-        if not isinstance(self._availability_callbacks, set):
-            self._availability_callbacks = set(self._availability_callbacks)
         self._availability_callbacks.discard(callback)
 
     def _notify_availability(self, *, available: bool) -> None:
         """Notify all registered availability callbacks."""
-        if not isinstance(self._availability_callbacks, set):
-            self._availability_callbacks = set(self._availability_callbacks)
         for callback in tuple(self._availability_callbacks):
             try:
                 callback(available)

--- a/custom_components/bravia_quad/bravia_quad_client.py
+++ b/custom_components/bravia_quad/bravia_quad_client.py
@@ -60,6 +60,19 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_BASS_LEVEL = 1  # MID
 DEFAULT_DRC = "auto"
 
+# Reconnection parameters
+RECONNECT_DELAY_INITIAL = 1.0  # seconds
+RECONNECT_DELAY_MAX = 60.0  # seconds
+RECONNECT_DELAY_MULTIPLIER = 2.0
+
+
+class _ReconnectNeededError(Exception):
+    """Internal signal that the notification loop should retry connection."""
+
+    def __init__(self, next_delay: float) -> None:
+        super().__init__()
+        self.next_delay = next_delay
+
 
 class BraviaQuadClient:
     """Client for Bravia Quad TCP communication."""
@@ -93,6 +106,7 @@ class BraviaQuadClient:
         self._pending_responses: dict[int, asyncio.Future] = {}
         self._listener_task: asyncio.Task | None = None
         self._background_tasks: set[asyncio.Task] = set()
+        self._availability_callbacks: list[Callable[[bool], None]] = []
 
     async def async_connect(self) -> None:
         """Connect to the Bravia Quad device."""
@@ -121,6 +135,19 @@ class BraviaQuadClient:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._listener_task
             self._listener_task = None
+        await self._async_close_connection()
+
+        # Cancel any background tasks
+        for task in self._background_tasks:
+            task.cancel()
+        if self._background_tasks:
+            await asyncio.gather(*self._background_tasks, return_exceptions=True)
+        self._background_tasks.clear()
+
+        _LOGGER.info("Disconnected from Bravia Quad")
+
+    async def _async_close_connection(self) -> None:
+        """Close the socket connection and fail pending commands."""
         if self._writer:
             self._writer.close()
             with contextlib.suppress(OSError):
@@ -135,14 +162,13 @@ class BraviaQuadClient:
                 future.set_exception(ConnectionError("Disconnected"))
         self._pending_responses.clear()
 
-        # Cancel any background tasks
-        for task in self._background_tasks:
-            task.cancel()
-        if self._background_tasks:
-            await asyncio.gather(*self._background_tasks, return_exceptions=True)
-        self._background_tasks.clear()
-
-        _LOGGER.info("Disconnected from Bravia Quad")
+    async def _async_mark_disconnected(self) -> None:
+        """Mark connection as lost, clean up, and notify entities."""
+        was_connected = self._connected
+        await self._async_close_connection()
+        if was_connected:
+            _LOGGER.warning("Connection to Bravia Quad lost")
+            self._notify_availability(available=False)
 
     async def async_test_connection(self) -> bool:
         """Test connection by sending a power status request."""
@@ -792,6 +818,25 @@ class BraviaQuadClient:
         _LOGGER.info("No subwoofer detected: device rejected bass level %d", test_value)
         return False
 
+    def register_availability_callback(self, callback: Callable[[bool], None]) -> None:
+        """Register a callback for connection state changes."""
+        self._availability_callbacks.append(callback)
+
+    def unregister_availability_callback(
+        self, callback: Callable[[bool], None]
+    ) -> None:
+        """Unregister a connection state change callback."""
+        with contextlib.suppress(ValueError):
+            self._availability_callbacks.remove(callback)
+
+    def _notify_availability(self, *, available: bool) -> None:
+        """Notify all registered availability callbacks."""
+        for callback in self._availability_callbacks:
+            try:
+                callback(available)
+            except Exception:
+                _LOGGER.exception("Error in availability callback")
+
     def register_notification_callback(self, feature: str, callback: Callable) -> None:
         """Register a callback for notifications."""
         if feature not in self._notification_callbacks:
@@ -817,45 +862,102 @@ class BraviaQuadClient:
         self._listener_task = asyncio.create_task(self._notification_loop())
 
     async def _notification_loop(self) -> None:
-        """Listen for real-time notifications from the device."""
+        """Listen for notifications from the device and reconnect on failure."""
         self._listening = True
+        reconnect_delay = RECONNECT_DELAY_INITIAL
         _LOGGER.info("Starting notification listener")
 
         try:
-            while self._listening and self._connected:
+            while self._listening:
                 try:
-                    if not self._reader:
-                        break
-
-                    data = await asyncio.wait_for(self._reader.read(1024), timeout=1.0)
-
-                    if not data:
-                        await asyncio.sleep(0.1)
+                    # Reconnect if disconnected
+                    if not self._connected:
+                        await self._async_attempt_reconnect(reconnect_delay)
+                        reconnect_delay = RECONNECT_DELAY_INITIAL
                         continue
 
-                    response_str = data.decode("utf-8", errors="replace").strip()
-                    if not response_str:
-                        continue
-
-                    messages = self._decode_json_stream(response_str)
-                    if not messages:
-                        continue
-
-                    for message in messages:
-                        await self._process_incoming_message(message)
+                    reconnect_delay = await self._async_read_and_process(
+                        reconnect_delay
+                    )
+                except _ReconnectNeededError as exc:
+                    reconnect_delay = exc.next_delay
                 except TimeoutError:
                     continue
                 except asyncio.CancelledError:
                     raise
-                except OSError:
-                    _LOGGER.exception("Error in notification listener")
-                    await asyncio.sleep(1.0)
         except asyncio.CancelledError:
             _LOGGER.info("Notification listener cancelled")
             raise
         finally:
             self._listening = False
             _LOGGER.info("Notification listener stopped")
+
+    async def _async_attempt_reconnect(self, delay: float) -> None:
+        """Try to reconnect; raise _ReconnectNeededError on failure."""
+        try:
+            await self.async_connect()
+            # Notify availability immediately — state fetch is
+            # scheduled as a background task because it sends
+            # commands whose responses are read by this loop.
+            self._notify_availability(available=True)
+            task = asyncio.create_task(self.async_fetch_all_states())
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+            _LOGGER.info("Reconnected to Bravia Quad")
+        except (OSError, ConnectionError, TimeoutError):
+            _LOGGER.debug(
+                "Reconnection attempt failed, retrying in %.1f seconds",
+                delay,
+            )
+            await asyncio.sleep(delay)
+            raise _ReconnectNeededError(
+                min(delay * RECONNECT_DELAY_MULTIPLIER, RECONNECT_DELAY_MAX)
+            ) from None
+
+    async def _async_read_and_process(self, reconnect_delay: float) -> float:
+        """
+        Read data from the device and process messages.
+
+        Returns the (possibly reset) reconnect delay.  Raises
+        ``_ReconnectNeededError`` when the connection is lost.
+        """
+        if not self._reader:
+            await self._async_mark_disconnected()
+            raise _ReconnectNeededError(reconnect_delay)
+
+        try:
+            data = await asyncio.wait_for(self._reader.read(1024), timeout=1.0)
+        except OSError:
+            _LOGGER.warning("Connection error in notification listener")
+            await self._async_mark_disconnected()
+            await asyncio.sleep(reconnect_delay)
+            raise _ReconnectNeededError(
+                min(
+                    reconnect_delay * RECONNECT_DELAY_MULTIPLIER,
+                    RECONNECT_DELAY_MAX,
+                )
+            ) from None
+
+        if not data:
+            # EOF - remote closed connection
+            _LOGGER.warning("Connection closed by device (EOF)")
+            await self._async_mark_disconnected()
+            await asyncio.sleep(reconnect_delay)
+            raise _ReconnectNeededError(
+                min(
+                    reconnect_delay * RECONNECT_DELAY_MULTIPLIER,
+                    RECONNECT_DELAY_MAX,
+                )
+            )
+
+        response_str = data.decode("utf-8", errors="replace").strip()
+        if response_str:
+            messages = self._decode_json_stream(response_str)
+            for message in messages:
+                await self._process_incoming_message(message)
+
+        # Reset backoff on successful data read
+        return RECONNECT_DELAY_INITIAL
 
     @property
     def is_connected(self) -> bool:

--- a/custom_components/bravia_quad/bravia_quad_client.py
+++ b/custom_components/bravia_quad/bravia_quad_client.py
@@ -820,18 +820,23 @@ class BraviaQuadClient:
 
     def register_availability_callback(self, callback: Callable[[bool], None]) -> None:
         """Register a callback for connection state changes."""
-        self._availability_callbacks.append(callback)
+        if not isinstance(self._availability_callbacks, set):
+            self._availability_callbacks = set(self._availability_callbacks)
+        self._availability_callbacks.add(callback)
 
     def unregister_availability_callback(
         self, callback: Callable[[bool], None]
     ) -> None:
         """Unregister a connection state change callback."""
-        with contextlib.suppress(ValueError):
-            self._availability_callbacks.remove(callback)
+        if not isinstance(self._availability_callbacks, set):
+            self._availability_callbacks = set(self._availability_callbacks)
+        self._availability_callbacks.discard(callback)
 
     def _notify_availability(self, *, available: bool) -> None:
         """Notify all registered availability callbacks."""
-        for callback in self._availability_callbacks:
+        if not isinstance(self._availability_callbacks, set):
+            self._availability_callbacks = set(self._availability_callbacks)
+        for callback in tuple(self._availability_callbacks):
             try:
                 callback(available)
             except Exception:

--- a/custom_components/bravia_quad/button.py
+++ b/custom_components/bravia_quad/button.py
@@ -12,7 +12,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from .const import CONF_HAS_SUBWOOFER, DOMAIN
-from .helpers import get_device_info
+from .helpers import BraviaQuadAvailabilityMixin, get_device_info
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -40,7 +40,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class BraviaQuadDetectSubwooferButton(ButtonEntity):
+class BraviaQuadDetectSubwooferButton(BraviaQuadAvailabilityMixin, ButtonEntity):
     """Button to detect subwoofer presence."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -127,7 +127,7 @@ class BraviaQuadDetectSubwooferButton(ButtonEntity):
                 )
 
 
-class BraviaQuadBluetoothPairingButton(ButtonEntity):
+class BraviaQuadBluetoothPairingButton(BraviaQuadAvailabilityMixin, ButtonEntity):
     """Button to trigger Bluetooth pairing mode."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC

--- a/custom_components/bravia_quad/helpers.py
+++ b/custom_components/bravia_quad/helpers.py
@@ -11,6 +11,7 @@ from homeassistant.const import CONF_MAC, CONF_NAME
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
+from homeassistant.helpers.entity import Entity
 
 from .const import CONF_MODEL, DEFAULT_MODEL, DOMAIN
 
@@ -151,7 +152,7 @@ def get_device_info(entry: ConfigEntry) -> DeviceInfo:
     )
 
 
-class BraviaQuadAvailabilityMixin:
+class BraviaQuadAvailabilityMixin(Entity):
     """
     Mixin that tracks connection availability for Bravia Quad entities.
 
@@ -171,17 +172,17 @@ class BraviaQuadAvailabilityMixin:
 
     def _on_availability_changed(self, _available: bool) -> None:  # noqa: FBT001
         """Handle connection availability change."""
-        self.async_write_ha_state()  # type: ignore[attr-defined]
+        self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
         """Register availability callback when entity is added."""
-        await super().async_added_to_hass()  # type: ignore[misc]
+        await super().async_added_to_hass()
         self._client.register_availability_callback(self._on_availability_changed)
 
     async def async_will_remove_from_hass(self) -> None:
         """Unregister availability callback when entity is removed."""
         self._client.unregister_availability_callback(self._on_availability_changed)
-        await super().async_will_remove_from_hass()  # type: ignore[misc]
+        await super().async_will_remove_from_hass()
 
 
 class BraviaQuadNotificationMixin(BraviaQuadAvailabilityMixin):

--- a/custom_components/bravia_quad/helpers.py
+++ b/custom_components/bravia_quad/helpers.py
@@ -180,8 +180,8 @@ class BraviaQuadAvailabilityMixin:
 
     async def async_will_remove_from_hass(self) -> None:
         """Unregister availability callback when entity is removed."""
-        await super().async_will_remove_from_hass()  # type: ignore[misc]
         self._client.unregister_availability_callback(self._on_availability_changed)
+        await super().async_will_remove_from_hass()  # type: ignore[misc]
 
 
 class BraviaQuadNotificationMixin(BraviaQuadAvailabilityMixin):

--- a/custom_components/bravia_quad/helpers.py
+++ b/custom_components/bravia_quad/helpers.py
@@ -151,7 +151,40 @@ def get_device_info(entry: ConfigEntry) -> DeviceInfo:
     )
 
 
-class BraviaQuadNotificationMixin:
+class BraviaQuadAvailabilityMixin:
+    """
+    Mixin that tracks connection availability for Bravia Quad entities.
+
+    Subclasses must define:
+    - _client: BraviaQuadClient instance
+
+    Provides an `available` property that reflects the TCP connection state
+    and automatically updates HA when the connection drops or recovers.
+    """
+
+    _client: BraviaQuadClient
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._client.is_connected
+
+    def _on_availability_changed(self, _available: bool) -> None:  # noqa: FBT001
+        """Handle connection availability change."""
+        self.async_write_ha_state()  # type: ignore[attr-defined]
+
+    async def async_added_to_hass(self) -> None:
+        """Register availability callback when entity is added."""
+        await super().async_added_to_hass()  # type: ignore[misc]
+        self._client.register_availability_callback(self._on_availability_changed)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unregister availability callback when entity is removed."""
+        await super().async_will_remove_from_hass()  # type: ignore[misc]
+        self._client.unregister_availability_callback(self._on_availability_changed)
+
+
+class BraviaQuadNotificationMixin(BraviaQuadAvailabilityMixin):
     """
     Mixin for entities that subscribe to Bravia Quad notifications.
 
@@ -161,7 +194,6 @@ class BraviaQuadNotificationMixin:
     - _on_notification: async callback method to handle notifications
     """
 
-    _client: BraviaQuadClient
     _notification_feature: str
 
     async def _on_notification(self, value: str) -> None:
@@ -170,14 +202,14 @@ class BraviaQuadNotificationMixin:
 
     async def async_added_to_hass(self) -> None:
         """Register notification callback when entity is added."""
-        await super().async_added_to_hass()  # type: ignore[misc]
+        await super().async_added_to_hass()
         self._client.register_notification_callback(
             self._notification_feature, self._on_notification
         )
 
     async def async_will_remove_from_hass(self) -> None:
         """Unregister notification callback when entity is removed."""
-        await super().async_will_remove_from_hass()  # type: ignore[misc]
+        await super().async_will_remove_from_hass()
         self._client.unregister_notification_callback(
             self._notification_feature, self._on_notification
         )

--- a/custom_components/bravia_quad/media_player.py
+++ b/custom_components/bravia_quad/media_player.py
@@ -25,7 +25,7 @@ from .const import (
     POWER_OFF,
     POWER_ON,
 )
-from .helpers import VolumeTransitionMixin, get_device_info
+from .helpers import BraviaQuadAvailabilityMixin, VolumeTransitionMixin, get_device_info
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -47,7 +47,9 @@ async def async_setup_entry(
     async_add_entities([BraviaQuadMediaPlayer(client, entry)])
 
 
-class BraviaQuadMediaPlayer(VolumeTransitionMixin, MediaPlayerEntity):
+class BraviaQuadMediaPlayer(
+    BraviaQuadAvailabilityMixin, VolumeTransitionMixin, MediaPlayerEntity
+):
     """Representation of a Bravia Quad soundbar as a media player."""
 
     _attr_device_class = MediaPlayerDeviceClass.SPEAKER

--- a/scripts/simulate_disconnect.py
+++ b/scripts/simulate_disconnect.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+Simulate a Bravia Quad device disconnect and reconnect scenario.
+
+Starts a fake TCP server that mimics the Bravia Quad protocol, connects the
+client, then kills the server to simulate a network drop. After a pause, the
+server restarts and the client should automatically reconnect.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+
+# Add the project root so custom_components is importable
+sys.path.insert(0, "/workspaces/bravia-quad-homeassistant")
+
+from custom_components.bravia_quad.bravia_quad_client import BraviaQuadClient
+from custom_components.bravia_quad.const import DEFAULT_PORT
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s  %(levelname)-8s  %(name)s  %(message)s",
+)
+_LOGGER = logging.getLogger("simulate")
+
+HOST = "127.0.0.1"
+PORT = DEFAULT_PORT  # 33336
+
+
+class FakeBraviaServer:
+    """Minimal TCP server that speaks enough of the Bravia Quad protocol."""
+
+    def __init__(self) -> None:
+        self._server: asyncio.Server | None = None
+        self._clients: list[asyncio.StreamWriter] = []
+
+    async def start(self) -> None:
+        """Start listening."""
+        self._server = await asyncio.start_server(
+            self._handle_client, HOST, PORT, reuse_address=True
+        )
+        _LOGGER.info("Fake Bravia server listening on %s:%s", HOST, PORT)
+
+    async def stop(self) -> None:
+        """Stop the server and close all client connections."""
+        for writer in self._clients:
+            writer.close()
+        self._clients.clear()
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+        _LOGGER.info("Fake Bravia server stopped")
+
+    async def _handle_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        """Handle a single client connection."""
+        peer = writer.get_extra_info("peername")
+        _LOGGER.info("Client connected from %s", peer)
+        self._clients.append(writer)
+
+        try:
+            while True:
+                data = await reader.read(4096)
+                if not data:
+                    break
+                text = data.decode("utf-8", errors="replace").strip()
+                _LOGGER.debug("Received: %s", text)
+
+                # Parse and respond to each JSON command
+                for line in text.splitlines():
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        cmd = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    cmd_type = cmd.get("type")
+                    feature = cmd.get("feature", "")
+                    cmd_id = cmd.get("id", 0)
+
+                    if cmd_type == "get":
+                        # Return a dummy value based on feature
+                        value = self._get_value(feature)
+                        resp = {
+                            "id": cmd_id,
+                            "type": "result",
+                            "feature": feature,
+                            "value": value,
+                        }
+                    elif cmd_type == "set":
+                        resp = {
+                            "id": cmd_id,
+                            "type": "result",
+                            "feature": feature,
+                            "value": "ACK",
+                        }
+                    else:
+                        resp = {"id": cmd_id, "type": "error", "value": "unknown"}
+
+                    resp_json = json.dumps(resp) + "\n"
+                    _LOGGER.debug("Sending: %s", resp_json.strip())
+                    writer.write(resp_json.encode())
+                    await writer.drain()
+        except (ConnectionResetError, BrokenPipeError):
+            _LOGGER.info("Client connection reset")
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._clients.discard(writer) if hasattr(self._clients, "discard") else None
+            writer.close()
+            _LOGGER.info("Client disconnected")
+
+    @staticmethod
+    def _get_value(feature: str) -> str | int:
+        """Return a dummy value for a feature."""
+        defaults: dict[str, str | int] = {
+            "main.power": "on",
+            "main.volumestep": 42,
+            "main.input": "tv",
+            "main.rearvolumestep": 0,
+            "main.bassstep": 1,
+            "audio.voiceenhancer": "upoff",
+            "audio.soundfield": "off",
+            "audio.nightmode": "off",
+            "hdmi.cec": "off",
+            "system.autostandby": "off",
+            "audio.drangecomp": "auto",
+            "audio.aav": "off",
+            "main.mute": "off",
+        }
+        return defaults.get(feature, "off")
+
+
+async def main() -> None:
+    """Run the full disconnect/reconnect simulation."""
+    server = FakeBraviaServer()
+    await server.start()
+
+    # --- Phase 1: Connect the client ---
+    _LOGGER.info("=" * 60)
+    _LOGGER.info("PHASE 1: Connecting client to fake server")
+    _LOGGER.info("=" * 60)
+
+    client = BraviaQuadClient(HOST, "SimTest")
+
+    # Track availability changes
+    availability_log: list[bool] = []
+
+    def on_availability(available: bool) -> None:
+        availability_log.append(available)
+        _LOGGER.info(
+            ">>> AVAILABILITY CHANGED: %s <<<",
+            "AVAILABLE" if available else "UNAVAILABLE",
+        )
+
+    client.register_availability_callback(on_availability)
+
+    await client.async_connect()
+    _LOGGER.info("Client connected: %s", client.is_connected)
+
+    await client.async_listen_for_notifications()
+    _LOGGER.info("Notification listener started")
+
+    # Fetch initial state
+    await client.async_fetch_all_states()
+    _LOGGER.info(
+        "Initial state - Power: %s, Volume: %d, Input: %s",
+        client.power_state,
+        client.volume,
+        client.input,
+    )
+
+    await asyncio.sleep(1)
+
+    # --- Phase 2: Kill the server (simulate disconnect) ---
+    _LOGGER.info("")
+    _LOGGER.info("=" * 60)
+    _LOGGER.info("PHASE 2: Stopping server to simulate disconnect")
+    _LOGGER.info("=" * 60)
+
+    await server.stop()
+
+    # Wait for the client to detect the disconnect
+    _LOGGER.info("Waiting for client to detect disconnect...")
+    for i in range(10):
+        await asyncio.sleep(1)
+        _LOGGER.info(
+            "  t+%ds  connected=%s  listening=%s",
+            i + 1,
+            client.is_connected,
+            client._listening,
+        )
+        if not client.is_connected:
+            _LOGGER.info("Client detected disconnect!")
+            break
+
+    assert not client.is_connected, "Client should have detected the disconnect"
+
+    # --- Phase 3: Restart the server (simulate device coming back) ---
+    _LOGGER.info("")
+    _LOGGER.info("=" * 60)
+    _LOGGER.info("PHASE 3: Restarting server to simulate reconnect")
+    _LOGGER.info("=" * 60)
+
+    await server.start()
+
+    # Wait for the client to reconnect
+    _LOGGER.info("Waiting for client to reconnect...")
+    for i in range(15):
+        await asyncio.sleep(1)
+        _LOGGER.info(
+            "  t+%ds  connected=%s  listening=%s",
+            i + 1,
+            client.is_connected,
+            client._listening,
+        )
+        if client.is_connected:
+            _LOGGER.info("Client reconnected!")
+            break
+
+    assert client.is_connected, "Client should have reconnected"
+
+    # Verify state was refreshed
+    _LOGGER.info(
+        "State after reconnect - Power: %s, Volume: %d, Input: %s",
+        client.power_state,
+        client.volume,
+        client.input,
+    )
+
+    # --- Phase 4: Clean up ---
+    _LOGGER.info("")
+    _LOGGER.info("=" * 60)
+    _LOGGER.info("PHASE 4: Cleanup")
+    _LOGGER.info("=" * 60)
+
+    await client.async_disconnect()
+    await server.stop()
+
+    _LOGGER.info("")
+    _LOGGER.info("=" * 60)
+    _LOGGER.info("SIMULATION COMPLETE")
+    _LOGGER.info("Availability transitions: %s", availability_log)
+    expected = [False, True]
+    if availability_log == expected:
+        _LOGGER.info("SUCCESS: Availability changed as expected %s", expected)
+    else:
+        _LOGGER.error("UNEXPECTED: Expected %s but got %s", expected, availability_log)
+        sys.exit(1)
+    _LOGGER.info("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,70 @@ def mock_setup_entry() -> Generator[None]:
         yield
 
 
+def _setup_feature_mocks(client: MagicMock) -> None:
+    """Configure feature-specific mock attributes on the client."""
+    # Power
+    client.async_get_power = AsyncMock(return_value="on")
+    client.async_set_power = AsyncMock(return_value=True)
+    client.power_state = "on"
+
+    # Volume
+    client.async_get_volume = AsyncMock(return_value=50)
+    client.async_set_volume = AsyncMock(return_value=True)
+    client.volume = 50
+    client.volume_step_interval = 0
+
+    # Input
+    client.async_get_input = AsyncMock(return_value="tv")
+    client.async_set_input = AsyncMock(return_value=True)
+    client.input = "tv"
+
+    # Rear level
+    client.async_get_rear_level = AsyncMock(return_value=0)
+    client.async_set_rear_level = AsyncMock(return_value=True)
+    client.rear_level = 0
+
+    # Bass level
+    client.async_get_bass_level = AsyncMock(return_value=0)
+    client.async_set_bass_level = AsyncMock(return_value=True)
+    client.bass_level = 0
+
+    # Voice enhancer
+    client.async_get_voice_enhancer = AsyncMock(return_value="upoff")
+    client.async_set_voice_enhancer = AsyncMock(return_value=True)
+    client.voice_enhancer = "upoff"
+
+    # Sound field
+    client.async_get_sound_field = AsyncMock(return_value="off")
+    client.async_set_sound_field = AsyncMock(return_value=True)
+    client.sound_field = "off"
+
+    # Night mode
+    client.async_get_night_mode = AsyncMock(return_value="off")
+    client.async_set_night_mode = AsyncMock(return_value=True)
+    client.night_mode = "off"
+
+    # HDMI CEC
+    client.async_get_hdmi_cec = AsyncMock(return_value="off")
+    client.async_set_hdmi_cec = AsyncMock(return_value=True)
+    client.hdmi_cec = "off"
+
+    # Auto standby
+    client.async_get_auto_standby = AsyncMock(return_value="off")
+    client.async_set_auto_standby = AsyncMock(return_value=True)
+    client.auto_standby = "off"
+
+    # Advanced Auto Volume
+    client.async_get_aav = AsyncMock(return_value="off")
+    client.async_set_aav = AsyncMock(return_value=True)
+    client.aav = "off"
+
+    # Mute
+    client.async_get_mute = AsyncMock(return_value="off")
+    client.async_set_mute = AsyncMock(return_value=True)
+    client.mute = "off"
+
+
 @pytest.fixture
 def mock_bravia_quad_client() -> Generator[MagicMock]:
     """Return a mocked BraviaQuadClient."""
@@ -126,66 +190,7 @@ def mock_bravia_quad_client() -> Generator[MagicMock]:
         client.async_listen_for_notifications = AsyncMock()
         client.async_fetch_all_states = AsyncMock()
 
-        # Power
-        client.async_get_power = AsyncMock(return_value="on")
-        client.async_set_power = AsyncMock(return_value=True)
-        client.power_state = "on"
-
-        # Volume
-        client.async_get_volume = AsyncMock(return_value=50)
-        client.async_set_volume = AsyncMock(return_value=True)
-        client.volume = 50
-        client.volume_step_interval = 0
-
-        # Input
-        client.async_get_input = AsyncMock(return_value="tv")
-        client.async_set_input = AsyncMock(return_value=True)
-        client.input = "tv"
-
-        # Rear level
-        client.async_get_rear_level = AsyncMock(return_value=0)
-        client.async_set_rear_level = AsyncMock(return_value=True)
-        client.rear_level = 0
-
-        # Bass level
-        client.async_get_bass_level = AsyncMock(return_value=0)
-        client.async_set_bass_level = AsyncMock(return_value=True)
-        client.bass_level = 0
-
-        # Voice enhancer
-        client.async_get_voice_enhancer = AsyncMock(return_value="upoff")
-        client.async_set_voice_enhancer = AsyncMock(return_value=True)
-        client.voice_enhancer = "upoff"
-
-        # Sound field
-        client.async_get_sound_field = AsyncMock(return_value="off")
-        client.async_set_sound_field = AsyncMock(return_value=True)
-        client.sound_field = "off"
-
-        # Night mode
-        client.async_get_night_mode = AsyncMock(return_value="off")
-        client.async_set_night_mode = AsyncMock(return_value=True)
-        client.night_mode = "off"
-
-        # HDMI CEC
-        client.async_get_hdmi_cec = AsyncMock(return_value="off")
-        client.async_set_hdmi_cec = AsyncMock(return_value=True)
-        client.hdmi_cec = "off"
-
-        # Auto standby
-        client.async_get_auto_standby = AsyncMock(return_value="off")
-        client.async_set_auto_standby = AsyncMock(return_value=True)
-        client.auto_standby = "off"
-
-        # Advanced Auto Volume
-        client.async_get_aav = AsyncMock(return_value="off")
-        client.async_set_aav = AsyncMock(return_value=True)
-        client.aav = "off"
-
-        # Mute
-        client.async_get_mute = AsyncMock(return_value="off")
-        client.async_set_mute = AsyncMock(return_value=True)
-        client.mute = "off"
+        _setup_feature_mocks(client)
 
         # Send command (for bluetooth pairing)
         client.async_send_command = AsyncMock(return_value={"value": "ACK"})
@@ -193,6 +198,11 @@ def mock_bravia_quad_client() -> Generator[MagicMock]:
         # Notification callbacks
         client.register_notification_callback = MagicMock()
         client.unregister_notification_callback = MagicMock()
+
+        # Availability
+        client.register_availability_callback = MagicMock()
+        client.unregister_availability_callback = MagicMock()
+        client.is_connected = True
 
         yield client
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -357,8 +357,8 @@ async def test_volume_step_interval_cancellation_on_remove(
     component = hass.data["number"]
     entity = next(ent for ent in component.entities if ent.entity_id == volume_id)
 
-    assert entity._transition_task is not None  # noqa: SLF001
-    task = entity._transition_task  # noqa: SLF001
+    assert entity._transition_task is not None
+    task = entity._transition_task
 
     # Remove the entity (simulating removal from HA)
     await entity.async_will_remove_from_hass()
@@ -369,7 +369,7 @@ async def test_volume_step_interval_cancellation_on_remove(
 
     # The task should be cancelled
     assert task.cancelled() or task.done()
-    assert entity._transition_task is None  # noqa: SLF001
+    assert entity._transition_task is None
     assert cancelled is True
 
 
@@ -427,7 +427,7 @@ async def test_volume_slider_does_not_update_during_transition(
 
     # Simulate device sending back notification with intermediate value
     # This should be ignored during transition
-    await entity._on_notification(51)  # noqa: SLF001
+    await entity._on_notification(51)
 
     # State should still be target value, not the notification value
     state = hass.states.get(volume_id)
@@ -442,13 +442,13 @@ async def test_volume_slider_does_not_update_during_transition(
     await hass.async_block_till_done()
 
     # Transition should be complete
-    assert entity._transition_in_progress is False  # noqa: SLF001
+    assert entity._transition_in_progress is False
 
     # Advance past the grace period so notifications are accepted again
-    entity._notification_suppressed_until = 0.0  # noqa: SLF001
+    entity._notification_suppressed_until = 0.0
 
     # Now notifications should update the state
-    await entity._on_notification(55)  # noqa: SLF001
+    await entity._on_notification(55)
     state = hass.states.get(volume_id)
     assert state is not None
     assert state.state == "55"
@@ -551,7 +551,7 @@ async def test_volume_transition_flag_reset_on_cancel(
         blocking=True,
     )
 
-    assert entity._transition_in_progress is True  # noqa: SLF001
+    assert entity._transition_in_progress is True
 
     # Notifications should be suppressed during active transition
     assert entity.should_suppress_volume_notification() is True
@@ -577,7 +577,7 @@ async def test_volume_transition_flag_reset_on_cancel(
     )
 
     # With interval=0, no transition should be in progress
-    assert entity._transition_in_progress is False  # noqa: SLF001
+    assert entity._transition_in_progress is False
 
     # Cleanup
     volume_blocked.set()
@@ -613,20 +613,20 @@ async def test_volume_notification_accepted_after_transition(
             blocking=True,
         )
         # Wait for the transition task to complete within the patch context
-        if entity._transition_task:  # noqa: SLF001
-            await entity._transition_task  # noqa: SLF001
+        if entity._transition_task:
+            await entity._transition_task
 
     # Transition should be complete
-    assert entity._transition_in_progress is False  # noqa: SLF001
+    assert entity._transition_in_progress is False
 
     # Notifications should still be suppressed during grace period
     assert entity.should_suppress_volume_notification() is True
 
     # Advance past the grace period
-    entity._notification_suppressed_until = 0.0  # noqa: SLF001
+    entity._notification_suppressed_until = 0.0
 
     # Now a notification should update the state
-    await entity._on_notification(45)  # noqa: SLF001
+    await entity._on_notification(45)
     state = hass.states.get(volume_id)
     assert state is not None
     assert state.state == "45"

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -1,0 +1,322 @@
+"""Tests for the Bravia Quad reconnection and availability functionality."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.const import STATE_UNAVAILABLE, Platform
+
+from custom_components.bravia_quad.bravia_quad_client import BraviaQuadClient
+
+from .conftest import get_entity_id_by_unique_id_suffix
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import entity_registry as er
+
+
+def _get_availability_callback(mock_client: MagicMock) -> Callable | None:
+    """Get the last registered availability callback."""
+    callback = None
+    for call_args in mock_client.register_availability_callback.call_args_list:
+        callback = call_args[0][0]
+    return callback
+
+
+def _notify_all_availability(mock_client: MagicMock, *, available: bool) -> None:
+    """Invoke all registered availability callbacks, simulating the real client."""
+    for call_args in mock_client.register_availability_callback.call_args_list:
+        callback = call_args[0][0]
+        callback(available)
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Return platforms to test."""
+    return [Platform.BUTTON, Platform.MEDIA_PLAYER, Platform.SWITCH]
+
+
+def _setup_mock_stream(client: BraviaQuadClient) -> MagicMock:
+    """Set up mock reader/writer on client and mark connected."""
+    mock_reader = MagicMock()
+    client._reader = mock_reader
+    client._writer = MagicMock()
+    client._writer.close = MagicMock()
+    client._writer.wait_closed = AsyncMock()
+    client._connected = True
+    return mock_reader
+
+
+# --- Client unit tests ---
+
+
+class TestClientReconnection:
+    """Tests for BraviaQuadClient reconnection logic."""
+
+    async def test_mark_disconnected_notifies_availability(self) -> None:
+        """Test that _async_mark_disconnected notifies availability callbacks."""
+        client = BraviaQuadClient("192.168.1.100", "Test")
+        callback = MagicMock()
+        client.register_availability_callback(callback)
+
+        client._connected = True
+
+        await client._async_mark_disconnected()
+
+        assert not client.is_connected
+        callback.assert_called_once_with(False)
+
+    async def test_mark_disconnected_when_already_disconnected(self) -> None:
+        """Test that _async_mark_disconnected is a no-op when already disconnected."""
+        client = BraviaQuadClient("192.168.1.100", "Test")
+        callback = MagicMock()
+        client.register_availability_callback(callback)
+
+        client._connected = False
+
+        await client._async_mark_disconnected()
+
+        callback.assert_not_called()
+
+    async def test_mark_disconnected_fails_pending_commands(self) -> None:
+        """Test that pending commands are failed on disconnect."""
+        client = BraviaQuadClient("192.168.1.100", "Test")
+        client._connected = True
+
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        client._pending_responses[42] = future
+
+        await client._async_mark_disconnected()
+
+        assert future.done()
+        with pytest.raises(ConnectionError):
+            future.result()
+
+    async def test_register_unregister_availability_callback(self) -> None:
+        """Test registering and unregistering availability callbacks."""
+        client = BraviaQuadClient("192.168.1.100", "Test")
+        callback = MagicMock()
+
+        client.register_availability_callback(callback)
+        assert callback in client._availability_callbacks
+
+        client.unregister_availability_callback(callback)
+        assert callback not in client._availability_callbacks
+
+    async def test_unregister_nonexistent_callback_is_safe(self) -> None:
+        """Test that unregistering a non-existent callback doesn't raise."""
+        client = BraviaQuadClient("192.168.1.100", "Test")
+        callback = MagicMock()
+
+        # Should not raise
+        client.unregister_availability_callback(callback)
+
+    async def test_notification_loop_reconnects_on_eof(self) -> None:
+        """Test that the notification loop reconnects when EOF is received."""
+        client = BraviaQuadClient("192.168.1.100", "Test")
+        availability_callback = MagicMock()
+        client.register_availability_callback(availability_callback)
+
+        read_count = 0
+
+        async def mock_read(n: int) -> bytes:
+            nonlocal read_count
+            read_count += 1
+            if read_count == 1:
+                return b""
+            client._listening = False
+            return b""
+
+        mock_reader = _setup_mock_stream(client)
+        mock_reader.read = mock_read
+
+        with patch.object(
+            client,
+            "async_connect",
+            side_effect=ConnectionError,
+        ):
+            client._listening = True
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    client._notification_loop(),
+                    timeout=3.0,
+                )
+
+        assert not client.is_connected
+        availability_callback.assert_called_with(False)
+
+    async def test_notification_loop_reconnects_on_os_error(self) -> None:
+        """Test that the notification loop reconnects on OSError."""
+        client = BraviaQuadClient("192.168.1.100", "Test")
+        availability_callback = MagicMock()
+        client.register_availability_callback(availability_callback)
+
+        async def mock_read(_n: int) -> bytes:
+            msg = "Connection reset"
+            raise OSError(msg)
+
+        mock_reader = _setup_mock_stream(client)
+        mock_reader.read = mock_read
+
+        async def mock_connect() -> None:
+            client._listening = False
+            raise ConnectionError
+
+        with patch.object(client, "async_connect", side_effect=mock_connect):
+            client._listening = True
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    client._notification_loop(),
+                    timeout=3.0,
+                )
+
+        assert not client.is_connected
+        availability_callback.assert_called_with(False)
+
+    async def test_notification_loop_successful_reconnect(self) -> None:
+        """Test that the notification loop successfully reconnects."""
+        client = BraviaQuadClient("192.168.1.100", "Test")
+        availability_callback = MagicMock()
+        client.register_availability_callback(availability_callback)
+
+        read_count = 0
+
+        async def mock_read(_n: int) -> bytes:
+            nonlocal read_count
+            read_count += 1
+            if read_count == 1:
+                return b""
+            client._listening = False
+            return b""
+
+        mock_reader = _setup_mock_stream(client)
+        mock_reader.read = mock_read
+
+        async def mock_connect() -> None:
+            client._connected = True
+            client._reader = mock_reader
+            client._writer = MagicMock()
+            client._writer.close = MagicMock()
+            client._writer.wait_closed = AsyncMock()
+
+        with (
+            patch.object(client, "async_connect", side_effect=mock_connect),
+            patch.object(client, "async_fetch_all_states", new_callable=AsyncMock),
+        ):
+            client._listening = True
+            await asyncio.wait_for(
+                client._notification_loop(),
+                timeout=5.0,
+            )
+
+        calls = availability_callback.call_args_list
+        assert any(c[0] == (False,) for c in calls)
+        assert any(c[0] == (True,) for c in calls)
+
+
+# --- Integration-level entity availability tests ---
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_entities_available_when_connected(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that entities are available when client is connected."""
+    entity_id = get_entity_id_by_unique_id_suffix(entity_registry, "_media_player")
+    assert entity_id is not None
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_entities_unavailable_when_disconnected(
+    hass: HomeAssistant,
+    mock_bravia_quad_client: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that entities become unavailable when connection is lost."""
+    entity_id = get_entity_id_by_unique_id_suffix(entity_registry, "_media_player")
+    assert entity_id is not None
+
+    mock_bravia_quad_client.is_connected = False
+    _notify_all_availability(mock_bravia_quad_client, available=False)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_entities_recover_after_reconnect(
+    hass: HomeAssistant,
+    mock_bravia_quad_client: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that entities recover availability after reconnection."""
+    entity_id = get_entity_id_by_unique_id_suffix(entity_registry, "_media_player")
+    assert entity_id is not None
+
+    mock_bravia_quad_client.is_connected = False
+    _notify_all_availability(mock_bravia_quad_client, available=False)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    mock_bravia_quad_client.is_connected = True
+    _notify_all_availability(mock_bravia_quad_client, available=True)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_switch_unavailable_when_disconnected(
+    hass: HomeAssistant,
+    mock_bravia_quad_client: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that switch entities become unavailable when disconnected."""
+    entity_id = get_entity_id_by_unique_id_suffix(entity_registry, "_night_mode")
+    assert entity_id is not None
+
+    mock_bravia_quad_client.is_connected = False
+    _notify_all_availability(mock_bravia_quad_client, available=False)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_button_unavailable_when_disconnected(
+    hass: HomeAssistant,
+    mock_bravia_quad_client: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that button entities become unavailable when disconnected."""
+    entity_id = get_entity_id_by_unique_id_suffix(entity_registry, "_detect_subwoofer")
+    if entity_id is None:
+        pytest.skip("Detect subwoofer button not found")
+
+    mock_bravia_quad_client.is_connected = False
+    _notify_all_availability(mock_bravia_quad_client, available=False)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -123,30 +123,20 @@ class TestClientReconnection:
         availability_callback = MagicMock()
         client.register_availability_callback(availability_callback)
 
-        read_count = 0
-
-        async def mock_read(n: int) -> bytes:
-            nonlocal read_count
-            read_count += 1
-            if read_count == 1:
-                return b""
-            client._listening = False
-            return b""
-
         mock_reader = _setup_mock_stream(client)
-        mock_reader.read = mock_read
+        mock_reader.read = AsyncMock(return_value=b"")
 
-        with patch.object(
-            client,
-            "async_connect",
-            side_effect=ConnectionError,
+        async def mock_connect() -> None:
+            # Stop the loop after the first failed reconnect attempt
+            client._listening = False
+            raise ConnectionError
+
+        with (
+            patch.object(client, "async_connect", new=mock_connect),
+            patch("asyncio.sleep", new_callable=AsyncMock),
         ):
             client._listening = True
-            with pytest.raises(asyncio.TimeoutError):
-                await asyncio.wait_for(
-                    client._notification_loop(),
-                    timeout=3.0,
-                )
+            await client._notification_loop()
 
         assert not client.is_connected
         availability_callback.assert_called_with(False)
@@ -157,24 +147,20 @@ class TestClientReconnection:
         availability_callback = MagicMock()
         client.register_availability_callback(availability_callback)
 
-        async def mock_read(_n: int) -> bytes:
-            msg = "Connection reset"
-            raise OSError(msg)
-
         mock_reader = _setup_mock_stream(client)
-        mock_reader.read = mock_read
+        mock_reader.read = AsyncMock(side_effect=OSError("Connection reset"))
 
         async def mock_connect() -> None:
+            # Stop the loop after the first failed reconnect attempt
             client._listening = False
             raise ConnectionError
 
-        with patch.object(client, "async_connect", side_effect=mock_connect):
+        with (
+            patch.object(client, "async_connect", new=mock_connect),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
             client._listening = True
-            with pytest.raises(asyncio.TimeoutError):
-                await asyncio.wait_for(
-                    client._notification_loop(),
-                    timeout=3.0,
-                )
+            await client._notification_loop()
 
         assert not client.is_connected
         availability_callback.assert_called_with(False)
@@ -206,14 +192,12 @@ class TestClientReconnection:
             client._writer.wait_closed = AsyncMock()
 
         with (
-            patch.object(client, "async_connect", side_effect=mock_connect),
+            patch.object(client, "async_connect", new=mock_connect),
             patch.object(client, "async_fetch_all_states", new_callable=AsyncMock),
+            patch("asyncio.sleep", new_callable=AsyncMock),
         ):
             client._listening = True
-            await asyncio.wait_for(
-                client._notification_loop(),
-                timeout=5.0,
-            )
+            await client._notification_loop()
 
         calls = availability_callback.call_args_list
         assert any(c[0] == (False,) for c in calls)


### PR DESCRIPTION
This bug fix should solve issue #82

This pull request introduces robust connection state tracking and automatic reconnection logic to the Bravia Quad integration. It enhances the client to handle connection drops gracefully, notifies Home Assistant entities of availability changes, and ensures entities reflect the current connection state. The update also introduces a new mixin for easy availability tracking across entities, and expands linter configuration for better code flexibility in scripts and tests.

**Connection management and reconnection logic:**

* Added automatic reconnection logic to `BraviaQuadClient`, including exponential backoff, reconnection attempts, and clear separation of connection teardown and reconnection (`bravia_quad_client.py`). [[1]](diffhunk://#diff-3707eb00fe57d86cf2939f7045c31a9897d49b393b8a9a8462852a7accf6adefR63-R75) [[2]](diffhunk://#diff-3707eb00fe57d86cf2939f7045c31a9897d49b393b8a9a8462852a7accf6adefL820-R961)
* Implemented `_ReconnectNeededError` for internal signaling during notification listening and reconnection (`bravia_quad_client.py`).
* Improved cleanup and state handling when disconnecting or losing connection, including proper cancellation of background tasks and notification of availability (`bravia_quad_client.py`). [[1]](diffhunk://#diff-3707eb00fe57d86cf2939f7045c31a9897d49b393b8a9a8462852a7accf6adefR138-R150) [[2]](diffhunk://#diff-3707eb00fe57d86cf2939f7045c31a9897d49b393b8a9a8462852a7accf6adefL138-R171)

**Entity availability tracking:**

* Introduced `BraviaQuadAvailabilityMixin`, a reusable mixin that tracks and exposes connection availability for Home Assistant entities, and ensures entities update their state when the connection drops or recovers (`helpers.py`). Entities like `BraviaQuadMediaPlayer`, `BraviaQuadDetectSubwooferButton`, and `BraviaQuadBluetoothPairingButton` now use this mixin (`media_player.py`, `button.py`, `helpers.py`). [[1]](diffhunk://#diff-3b25cf523537c24168a644f544794131a4cd3ce5503aafc1bdcb3ad2f498caf7L154-R187) [[2]](diffhunk://#diff-0ccee5e081ee0789d8950c509ae0e136fc2ab87198ffb49276cfc12a0572bed9L28-R28) [[3]](diffhunk://#diff-0ccee5e081ee0789d8950c509ae0e136fc2ab87198ffb49276cfc12a0572bed9L50-R52) [[4]](diffhunk://#diff-9715a70de53aefd55ef79651c5a339995b2f56ea4d0323f5af5c0b258fc92416L15-R15) [[5]](diffhunk://#diff-9715a70de53aefd55ef79651c5a339995b2f56ea4d0323f5af5c0b258fc92416L43-R43) [[6]](diffhunk://#diff-9715a70de53aefd55ef79651c5a339995b2f56ea4d0323f5af5c0b258fc92416L130-R130)

**Notification and callback improvements:**

* Added registration and notification system for availability callbacks in `BraviaQuadClient`, allowing entities to subscribe to connection state changes (`bravia_quad_client.py`). [[1]](diffhunk://#diff-3707eb00fe57d86cf2939f7045c31a9897d49b393b8a9a8462852a7accf6adefR109) [[2]](diffhunk://#diff-3707eb00fe57d86cf2939f7045c31a9897d49b393b8a9a8462852a7accf6adefR821-R839)

**Linting and code quality:**

* Expanded `.ruff.toml` linter configuration to allow more flexibility in scripts and tests, such as ignoring docstring requirements, allowing private member access, and other test/script-specific rules.

**Other improvements:**

* Minor simplification and clarification in the notification mixin and entity setup (`helpers.py`). [[1]](diffhunk://#diff-3b25cf523537c24168a644f544794131a4cd3ce5503aafc1bdcb3ad2f498caf7L164) [[2]](diffhunk://#diff-3b25cf523537c24168a644f544794131a4cd3ce5503aafc1bdcb3ad2f498caf7L173-R212)

These changes make the integration more resilient to network issues and ensure Home Assistant entities accurately reflect the device's online/offline status.