### PR TITLE
Improve reconnection logic to confirm connection before notification

### DIFF
--- a/custom_components/bravia_quad/bravia_quad_client.py
+++ b/custom_components/bravia_quad/bravia_quad_client.py
@@ -107,6 +107,7 @@ class BraviaQuadClient:
         self._listener_task: asyncio.Task | None = None
         self._background_tasks: set[asyncio.Task] = set()
         self._availability_callbacks: set[Callable[[bool], None]] = set()
+        self._pending_available_notify = False
 
     async def async_connect(self) -> None:
         """Connect to the Bravia Quad device."""
@@ -872,7 +873,9 @@ class BraviaQuadClient:
                     # Reconnect if disconnected
                     if not self._connected:
                         await self._async_attempt_reconnect(reconnect_delay)
-                        reconnect_delay = RECONNECT_DELAY_INITIAL
+                        # Don't reset backoff here — wait for a
+                        # successful data read to confirm the
+                        # connection is truly alive.
                         continue
 
                     reconnect_delay = await self._async_read_and_process(
@@ -895,14 +898,13 @@ class BraviaQuadClient:
         """Try to reconnect; raise _ReconnectNeededError on failure."""
         try:
             await self.async_connect()
-            # Notify availability immediately — state fetch is
-            # scheduled as a background task because it sends
-            # commands whose responses are read by this loop.
-            self._notify_availability(available=True)
+            # Don't notify availability yet — wait until the first
+            # successful data read confirms the connection is alive.
+            self._pending_available_notify = True
             task = asyncio.create_task(self.async_fetch_all_states())
             self._background_tasks.add(task)
             task.add_done_callback(self._background_tasks.discard)
-            _LOGGER.info("Reconnected to Bravia Quad")
+            _LOGGER.info("Reconnected to Bravia Quad (confirming...)")
         except (OSError, ConnectionError, TimeoutError):
             _LOGGER.debug(
                 "Reconnection attempt failed, retrying in %.1f seconds",
@@ -954,6 +956,13 @@ class BraviaQuadClient:
             messages = self._decode_json_stream(response_str)
             for message in messages:
                 await self._process_incoming_message(message)
+
+        # Connection confirmed — notify entities if this is the
+        # first successful read after a reconnect.
+        if self._pending_available_notify:
+            self._pending_available_notify = False
+            _LOGGER.info("Reconnection confirmed by device response")
+            self._notify_availability(available=True)
 
         # Reset backoff on successful data read
         return RECONNECT_DELAY_INITIAL

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -177,7 +177,12 @@ class TestClientReconnection:
             nonlocal read_count
             read_count += 1
             if read_count == 1:
+                # First read: EOF triggers disconnect + reconnect
                 return b""
+            if read_count == 2:
+                # Second read (after reconnect): valid data confirms connection
+                return b'{"type":"result","feature":"power","value":"off"}\n'
+            # Third read: stop the loop
             client._listening = False
             return b""
 


### PR DESCRIPTION
This pull request improves the reconnection logic in the `bravia_quad_client.py` to ensure that availability is only notified after a reconnection is truly confirmed by a successful data read, rather than immediately after a connection attempt. This change helps prevent false positives where the connection appears alive but has not yet been verified by actual communication with the device. The reconnection backoff is also now only reset after a confirmed successful read, and the related test is updated to reflect this behavior.

**Improvements to reconnection and availability notification:**

* Added a `_pending_available_notify` flag to defer notifying availability until after the first successful data read following a reconnect, instead of immediately after `async_connect()` is called. [[1]](diffhunk://#diff-3707eb00fe57d86cf2939f7045c31a9897d49b393b8a9a8462852a7accf6adefR110) [[2]](diffhunk://#diff-3707eb00fe57d86cf2939f7045c31a9897d49b393b8a9a8462852a7accf6adefL898-R907) [[3]](diffhunk://#diff-3707eb00fe57d86cf2939f7045c31a9897d49b393b8a9a8462852a7accf6adefR960-R966)
* Modified the reconnection logic to keep the backoff delay unchanged until a successful data read confirms the connection is alive, rather than resetting it after every reconnect attempt. [[1]](diffhunk://#diff-3707eb00fe57d86cf2939f7045c31a9897d49b393b8a9a8462852a7accf6adefL875-R878) [[2]](diffhunk://#diff-3707eb00fe57d86cf2939f7045c31a9897d49b393b8a9a8462852a7accf6adefR960-R966)

**Testing updates:**

* Updated the reconnection test (`test_reconnection.py`) to simulate the new behavior: the first read triggers a disconnect, the second read after reconnect provides valid data to confirm the connection, and only then is the loop stopped.