### PR TITLE
Add zeroconf discovery for Sony HT-A9 (original)

### DIFF
--- a/custom_components/bravia_quad/manifest.json
+++ b/custom_components/bravia_quad/manifest.json
@@ -19,6 +19,13 @@
         "manufacturer": "sony*",
         "model": "bravia theatre*"
       }
+    },
+    {
+      "type": "_airplay._tcp.local.",
+      "properties": {
+        "manufacturer": "sony*",
+        "model": "ht-a9*"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Enables zeroconf auto-discovery for the original Sony HT-A9 (2021), which is API-compatible with this integration but broadcasts mDNS values that don't match the existing matcher.

## Captured mDNS data

From a real HT-A9 on my home network, queried via `dns-sd -L` on macOS:

```
model=HT-A9
manufacturer=SONY
```

The existing matcher targets `model: "bravia theatre*"` (covering the 2024 line: Quad / Bar 8 / Bar 9), so it does not catch the original HT-A9. Owners currently have to add the integration via manual IP entry.

## Approach

- **Adds a new matcher block; the existing one is untouched.** Zero risk of regression for current users.
- **Lowercase pattern values** (`"sony*"`, `"ht-a9*"`) mirror the existing matcher's style — HA's zeroconf matcher is case-insensitive, so this matches the actual `SONY` / `HT-A9` broadcast values.
- **Wildcard `ht-a9*`** (rather than exact `ht-a9`) matches the existing matcher's wildcard style (`bravia theatre*`) and gracefully covers potential future minor variants.

## Notes

- The original HT-A9 has been confirmed working with this integration via manual IP setup; this PR addresses only the auto-discovery gap.
- No runtime, protocol, or async code is touched in this PR — config-only change.

Refs #77
